### PR TITLE
Fix crash if DLL path is longer than 127 chars

### DIFF
--- a/excel/src/xlw/XlfOper.cpp
+++ b/excel/src/xlw/XlfOper.cpp
@@ -1,5 +1,5 @@
 /*
- Copyright (C) 1998, 1999, 2001, 2002 Jérôme Lecomte
+ Copyright (C) 1998, 1999, 2001, 2002 Jï¿½rï¿½me Lecomte
  
  This file is part of XLW, a free-software/open-source C++ wrapper of the
  Excel C API - http://xlw.sourceforge.net/
@@ -375,7 +375,7 @@ int XlfOper::ConvertToString(char *& s) const throw()
 
   if (lpxloper_->xltype & xltypeStr)
   {
-    size_t n = lpxloper_->val.str[0];
+    size_t n = (unsigned char)lpxloper_->val.str[0];
     s = XlfExcel::Instance().GetMemory(n + 1);
     memcpy(s, lpxloper_->val.str + 1, n);
     s[n] = 0;


### PR DESCRIPTION
Avoid crashing Excel when the DLL's path is longer than 127 characters and the compiler is using signed chars (not sure if yours is but I found this bug myself just now and figured sharing is caring!)
